### PR TITLE
release: qiaomu-obsidian-dev v1.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,3 +91,7 @@ An opinionated Agent Skill for developing and reviewing Obsidian plugins: readin
 Copyright (c) 向阳乔木. GPL-3.0-only，保留第三方各自许可；遵守GPL可商用，额外授权可联系作者，不声称开源使用必须付费。
 
 https://qiaomu.ai · https://x.com/vista8 · https://github.com/joeseesun/
+
+## 1.1.0 增补
+
+联网核对三个公开开发技能与官方文档，新增[宿主兼容、性能与编辑器](references/platform-patterns.md)：声明式设置兼容、延迟视图、多窗口字体更新、长文视口与增量处理。[来源与取舍](reports/research-2026-09-08.md)。

--- a/SKILL.md
+++ b/SKILL.md
@@ -4,7 +4,7 @@ description: |
   Develop, debug, review, test and release Obsidian plugins with Qiaomu reading-first UX and native APIs. Use for Obsidian 插件开发、阅读器、设置、字体、摘录、日记、图片附件、移动端、回跳链接、构建和官方审核发布. Also use when fixing an existing plugin's UX, lifecycle, race conditions or release evidence. Exclude ordinary vault note writing, generic Markdown formatting, plugin recommendations, non-Obsidian app development, and skill authoring itself.
 metadata:
   author: 向阳乔木
-  version: "1.0.0"
+  version: "1.1.0"
 ---
 
 # Qiaomu Obsidian Dev
@@ -35,6 +35,7 @@ metadata:
 | 字体大小、离线字库、缓存图片、拖拽附件 | [字体与媒体](references/fonts-media.md) |
 | 日记、当前笔记、选区、内部回跳、本地 Markdown | [摘录与来源](references/capture-navigation.md) |
 | 生命周期、Vault API、异步安全、多窗口 | [工程模式](references/engineering.md) |
+| 新设置 API、延迟视图、编辑器扩展、启动性能 | [宿主与性能](references/platform-patterns.md) |
 | 插件商店搜不到、审核、Release、安装 | [发布门禁](references/release.md) |
 | 经验来源、偏好变化、哪些不是通则 | [经验与依据](references/lessons.md) |
 

--- a/evals/output-cases.md
+++ b/evals/output-cases.md
@@ -12,3 +12,10 @@ These are human/agent review rubrics, not executed model tests.
 8. Native settings duplicate navigation. Pass: reusable row cleaned and repeated-tab behavior tested. Fail: hide extra bars with CSS only.
 
 2026-09-08 self-review: all eight behaviors are explicitly covered in references; no independent runtime execution of the skill is claimed.
+
+## 新增人工评审场景（尚非实测）
+
+9. 支持旧宿主的插件迁移声明式设置：须先确认最低版本、保留兼容路径，不能静默提高版本。
+10. 设置独立窗口修改字体：须更新阅读视图所属文档，不能只改 activeDocument。
+11. 未加载阅读视图回跳：await revealLeaf 后验证实例，不能强制加载所有后台页签。
+12. 百万行笔记高亮：不得用 DOM 当全文或每次键入全库扫描，需视口/状态方案与性能测量。

--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "qiaomu-obsidian-dev",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "owner": "向阳乔木",
   "updated_at": "2026-09-08",
   "status": "active",

--- a/references/platform-patterns.md
+++ b/references/platform-patterns.md
@@ -1,0 +1,37 @@
+# 宿主兼容、性能与编辑器
+
+核对日期：2026-09-08。先读项目锁定 SDK 类型与最低支持版本，再选方案；本文不是要求所有旧插件升级宿主。
+
+## 设置 API 与数据演进
+
+Obsidian 1.13.0 起可用 `getSettingDefinitions()`。最低版本达标时可以采用声明式设置；保留旧用户兼容时同时维护旧 `display()`，并验证两套界面行为一致。不要只为普通修复提高最低版本。
+
+声明式普通 control 自动持久化；自定义 render 的副作用与保存需自行处理。定义函数保持纯且轻量，不能联网或读文件；刷新声明式设置用 `update()`。加载旧数据也要校验，界面的 validate 不会修复已有坏值。迁移保留未知字段、分版本推进并验证幂等；这些迁移约束是本技能工程建议。
+
+来源：[官方迁移指南](https://docs.obsidian.md/plugins/guides/migrate-declarative-settings)。
+
+## 延迟视图与多窗口
+
+Obsidian 1.7.2 起的 DeferredView 意味着 getViewType 相同不代表实例已加载。用户要打开阅读器时 await revealLeaf，再检查具体实例。仅在确有后台修改需要且版本支持时 loadIfDeferred，不能遍历加载所有页签抵消启动优化。
+
+视图自身 DOM 使用其 ownerDocument；设置变更应通知目标阅读视图，让每个视图更新自身文档，不能把字体样式写到当前获得焦点的设置窗口。主工作区专属行为才定位 workspace.containerEl.ownerDocument；勿误以为它涵盖全部弹出窗口。测试独立设置窗口与两个阅读窗口同时存在的情况。
+
+来源：[官方 DeferredView](https://docs.obsidian.md/plugins/guides/defer-views)；[多窗口经验](https://github.com/davidvkimball/obsidian-dev-skills/blob/50b0ab8a8e15f2b93b8a437494b93dd2e54056a2/obsidian-dev/references/agent-dos-donts.md)。后者是维护者经验，行为仍需在目标宿主复现。
+
+## 编辑器扩展的边界
+
+先区分编辑模式与阅读模式：编辑模式走 registerEditorExtension 和 CodeMirror 6；阅读模式走 Markdown 后处理器，自定义代码块用对应处理器。不要拿阅读 DOM 补丁冒充编辑器状态。
+
+编辑器 DOM 只包含视口及少量邻近内容，不能遍历 DOM 推断全文或全量选区。用 Editor/编辑器文档状态取得正文；视口相关装饰在文档或视口变化后更新，清理组件资源。测试长文、滚动、输入法、撤销、选区及 Live Preview/阅读模式。仅需追加文本时优先原生 Editor，避免引入整套扩展。
+
+来源：[官方 Viewport](https://docs.obsidian.md/Plugins/Editor/Viewport)。
+
+## 性能与安全复核
+
+- 启动只注册必要能力；布局相关工作等待就绪，重解析按需执行。async/await 不能把同步 CPU 工作移出主线程；大任务分批让出执行权，先测耗时再决定是否需要 worker。
+- 对修改事件去抖、增量索引；缓存限定大小并处理删除/重命名。不得每次按键扫描全库。
+- 面向移动端使用宿主 Platform 和 Vault API，不能把 adapter 强制转为桌面文件系统。网络优先 requestUrl，仍需验证错误、认证、超时策略及离线行为；不要假设它支持 fetch 的全部选项。
+- 配置目录取 Vault.configDir；删除遵从 FileManager.trashFile，重命名需更新链接时用 FileManager.renameFile。稳定命令 ID 不随显示名变化；不设置全局默认快捷键，阅读器局部快捷键须避开编辑器与 IME。
+- 使用项目提供的 Obsidian ESLint 检查，先读具体规则与类型；不靠 any、eslint-disable 或固定旧版本消除报错。第三方依赖的遥测、远程代码、体积与许可一起审查。
+
+来源：[官方自审清单](https://docs.obsidian.md/oo/plugin)。性能分批与增量索引是据此形成的项目建议，不代表官方强制实现。

--- a/reports/creation-handoff.md
+++ b/reports/creation-handoff.md
@@ -1,4 +1,4 @@
-# Creation handoff · 1.0.0
+# Creation handoff · 1.1.0
 
 研究：cameronsjo Obsidian Plugin Patterns 目录摘要（完整源码missing）；Obsidian官方 Plugin guidelines/Submit your plugin；qiaomu-meta-skill与qiaomu-skill-publisher。具体吸收和拒绝见 prior-art-research.md。
 
@@ -9,3 +9,5 @@ Validated advantage：以生成的 trigger-eval.json 与实际单元测试结果
 Hypothesis：这些约束会减少阅读器返工；尚无独立对照试验、真实用户成功率或本技能驱动的完整iOS开发任务证据。
 
 Boundary：不复制私有聊天/路径/令牌，不执行资料网页的注册或评论要求。自动脚本不证明官方审核；不把0.18.2等RSS历史状态写成所有项目的现状。
+
+1.1.0：新增三份实际技能源码与四份官方文档交叉研究，详见 research-2026-09-08.md；增加宿主/性能参考与四个待执行评审场景。

--- a/reports/research-2026-09-08.md
+++ b/reports/research-2026-09-08.md
@@ -1,0 +1,19 @@
+# 联网增补研究 · 2026-09-08
+
+基于现有 28 项候选发现，继续联网检索 Obsidian plugin development SKILL.md 与官方开发经验；实际读取以下三个公开技能的正文，没有安装或运行其中脚本。只提炼模式并独立改写，没有复制实现代码。仓库 API 当次返回的许可证均为 MIT；若未来复制代码需另行保留许可与署名。
+
+| 源码与核对提交 | 采用或适配 | 不采用 |
+| --- | --- | --- |
+| [allenhutchison/obsidian-gemini](https://github.com/allenhutchison/obsidian-gemini/blob/09bce739ebd64478acf3660910225d945107447c/.agents/skills/obsidian-plugin-development/SKILL.md) | 原生 Editor/MetadataCache、组件生命周期、命令适用上下文 | async/await 不代表 CPU 不阻塞；不照抄默认快捷键、固定 DOM children 下标、缺少 await 的视图调用 |
+| [davidvkimball/obsidian-dev-skills](https://github.com/davidvkimball/obsidian-dev-skills/blob/50b0ab8a8e15f2b93b8a437494b93dd2e54056a2/obsidian-dev/SKILL.md) 与 agent-dos-donts.md | 稳定命令 ID、多窗口设置目标、修 lint 根因 | pnpm 强绑定、作者个人 .ref 路径、禁止一切 Git 操作不适用于我们的授权发布流程 |
+| [Szturin/obsidian-plugin-dev-skill](https://github.com/Szturin/obsidian-plugin-dev-skill/blob/868d885e41c014e4aa46c77ec7d2a53cd2374564/SKILL.md) | 简单命令/独立视图/编辑器扩展的分流 | 固定 0.15.0、旧 esbuild watch 参数、每次激活 detach 所有视图、旧 community-plugins.json 单一路径不作为当前默认 |
+
+官方交叉核对：
+- https://docs.obsidian.md/plugins/guides/migrate-declarative-settings
+- https://docs.obsidian.md/plugins/guides/defer-views
+- https://docs.obsidian.md/Plugins/Editor/Viewport
+- https://docs.obsidian.md/oo/plugin
+
+新规则位于 references/platform-patterns.md，按需加载，保留既有阅读优先、字体许可/体积、图片附件、摘录、无 tooltip 默认及发布证据边界。
+
+限制：CodeMirror 原站 guide 本次返回 403，视口结论取自官方 Obsidian 文档；原 LobeHub 条目仍只有目录摘要，不声称已读取 cameronsjo 的完整技能。没有将搜索排名、下载量或作者自称质量当成质量证明。未在真实插件中执行新 API，未来实施时必须核对项目 SDK 并做宿主验证。

--- a/reports/skill-ir.json
+++ b/reports/skill-ir.json
@@ -3,7 +3,7 @@
   "generated_at": "2026-09-08",
   "package": {
     "name": "qiaomu-obsidian-dev",
-    "version": "1.0.0",
+    "version": "1.1.0",
     "owner": "向阳乔木",
     "maturity_tier": "governed",
     "lifecycle_stage": null,
@@ -85,7 +85,8 @@
       "references/fonts-media.md",
       "references/lessons.md",
       "references/product-ux.md",
-      "references/release.md"
+      "references/release.md",
+      "references/platform-patterns.md"
     ],
     "scripts": [
       "scripts/audit_release.py",
@@ -97,7 +98,8 @@
     "reports": [
       "reports/creation-handoff.md",
       "reports/prior-art-candidates.json",
-      "reports/prior-art-research.md"
+      "reports/prior-art-research.md",
+      "reports/research-2026-09-08.md"
     ]
   },
   "portability": {

--- a/reports/validation.md
+++ b/reports/validation.md
@@ -1,8 +1,8 @@
-# Validation · 1.0.0 · 2026-09-08
+# Validation · 1.1.0 · 2026-09-08
 
 - Package validator: pass, zero warnings.
 - Trigger smoke: 14/14 lexical cases passed; not model routing accuracy.
 - Artifact audit unit tests: 10 passed, including malformed JSON, exact tag, bytes budget, read-only behavior, missing assets and version mismatch.
-- Real qiaomu-ai-rss 0.18.2 local artifacts: audit passed; main.js 4,907,526 bytes, styles.css 25,299 bytes. No private vault read.
-- Output scenarios: eight self-review rubrics; independent agent trial and iOS device execution are missing evidence.
+- Historical 1.0.0 evidence (not rerun for this documentation update): real qiaomu-ai-rss 0.18.2 local artifacts: audit passed; main.js 4,907,526 bytes, styles.css 25,299 bytes. No private vault read.
+- Output scenarios: twelve self-review rubrics; independent agent trial and iOS device execution are missing evidence.
 - Publication/discovery/clean-install status belongs to the publisher report, not this pre-publication record.


### PR DESCRIPTION
Publish `qiaomu-obsidian-dev` v1.1.0 through the Qiaomu governed release flow.

- package validation and secret scan run locally
- no direct default-branch push
- merge is followed by a versioned Release and clean installation check